### PR TITLE
(tech) auto create gh-pages on CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.4"
 script:
-  - pip install -r requirements.txt
+  - pip install --upgrade -r requirements.txt
   - make
 after_success:
   - make docs-deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
 python:
   - "3.4"
-script: pip install -r requirements.txt && make
+script: 
+  - pip install -r requirements.txt
+  - make
+after_success:
+  - make deploy-docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "3.4"
-script: 
+script:
   - pip install -r requirements.txt
   - make
 after_success:
-  - make deploy-docs
+  - make docs-deploy

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Apache License
+                                Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 setup.py := python setup.py
 sphinx-build := sphinx-build ./docs ./build/docs -E -d ./.doctrees -q -n -b
+sphinx-deploy := travis-sphinx --source=./docs --outdir=./build/docs
 
 all: clean build test docs install
 
@@ -7,14 +8,13 @@ build:
 	$(setup.py) build
 
 test:
-	$(sphinx-build) doctest 
+	$(sphinx-build) doctest
 
 docs:
-	# todo: we shouldn't have to build with travis-sphinx
-	travis-sphinx --source=./docs --outdir=./build/docs build
+	$(sphinx-build) html
 
-deploy-docs:
-	travis-sphinx deploy
+docs-deploy:
+	$(sphinx-deploy) deploy
 
 install:
 	$(setup.py) install
@@ -40,6 +40,7 @@ help:
 	@echo '   make uninstall                   uninstall the built application    '
 	@echo '   make clean                       clean out all temporary files      '
 	@echo '   make docs                        generate application documentation '
+	@echo '   make docs-deploy                 deploy built docs to gh-pages      '
 	@echo '   make help                        displays this help text            '
 	@echo '                                                                       '
 	@echo 'DEFAULT:                                                               '

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ test:
 	$(sphinx-build) doctest 
 
 docs:
-	$(sphinx-build) html
+	# todo: we shouldn't have to build with travis-sphinx
+	travis-sphinx --source=./docs --outdir=./build/docs build
+
+deploy-docs:
+	travis-sphinx deploy
 
 install:
 	$(setup.py) install

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ todo_include_todos = True
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-html_static_path = ['_static']
+html_static_path = []
 html_extra_path = []
 html_sidebars = {}
 html_additional_pages = {}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-Welcome to thrustr's documentation!
+Welcome to tdu documentation!
 ===================================
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,3 @@
-.. thrustr documentation master file, created by
-   sphinx-quickstart on Mon Jul 25 20:58:36 2016.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 Welcome to thrustr's documentation!
 ===================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,8 @@ Welcome to tdu documentation!
 
    **/*
 
+There's not much here yet but we're working on it!
+   
 Indices and tables
 ==================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 check-manifest
 Sphinx
 sphinx-rtd-theme
+travis-sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 check-manifest
 Sphinx
 sphinx-rtd-theme
-git+git://github.com/Nate-Wilkins/travis-sphinx
+git+git://github.com/Nate-Wilkins/travis-sphinx@patch-1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 check-manifest
 Sphinx
 sphinx-rtd-theme
-travis-sphinx
+git+git://github.com/Nate-Wilkins/travis-sphinx

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,10 @@ setup(
     version = '0.0.1',
     description = 'Thruster design utility.',
     long_description = long_description,
-    url = 'https://github.com/runphilrun/ThrusterDesignUtility',
+    url = 'https://github.com/runphilrun/tdu',
     author = 'Phil-Linden',
     author_email = 'pjl7651@rit.edu',
     license = 'Apache-2.0',
-
-    # https://pypi.python.org/pypi?%3Aaction = list_classifiers
     classifiers = [
         'Development Status :: 1 - Planning',
         'Intended Audience :: Science/Research',
@@ -29,9 +27,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3 :: Only'
     ],
-
     keywords = '',
-
     package_dir = {'': 'src'},
     packages = find_packages('src'),
     entry_points = {


### PR DESCRIPTION
Use a fork of [travis-sphinx](https://github.com/Nate-Wilkins/travis-sphinx) to push built docs to a [gh-pages](https://pages.github.com/) branch on a successful `master` CI build. 
