### PR TITLE
(fix:#14) make deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.pypirc
 .tox/
 build/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ clean:
 	rm -rf ./src/thrusted.egg-info
 	rm -rf ./.doctrees
 
+deploy:
+	$(setup.py) register -r ${source}
+	$(setup.py) sdist upload -r ${source}
+
 help:
 	@echo 'Makefile build automation                                              '
 	@echo '                                                                       '


### PR DESCRIPTION
(fix:#14) Simplify the deployment process a bit.

``` bash
make deploy source="pypitest"
make deploy source="pypi"
```

Eventually we can make this automatic but right now you'll have to setup your `.pypirc` file and do [manual deployments](http://peterdowns.com/posts/first-time-with-pypi.html).

I've deployed version `0.0.1` which we might want to tag in our commit history. (ie sha:ab52b0a)
